### PR TITLE
fix: correct dist folder

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "types": "./dist/index.d.ts",
   "files": [
-    "dist/src",
+    "dist",
     "src"
   ],
   "scripts": {


### PR DESCRIPTION
Currently there is no dist folder published as `files` property in `package.json` is incorrect.

<img width="1622" height="812" alt="CleanShot 2025-10-08 at 01 18 57@2x" src="https://github.com/user-attachments/assets/37a7503d-a559-4088-a845-a9774242bf4f" />
